### PR TITLE
Bug: Check for status and not KYC status on customer refresh

### DIFF
--- a/screens/ProcessingApplicationScreen.tsx
+++ b/screens/ProcessingApplicationScreen.tsx
@@ -21,7 +21,7 @@ export default function ProcessingApplicationScreen(): JSX.Element {
   });
 
   const refreshCustomerPeriodically = async (): Promise<void> => {
-    if (customer.kyc_status === 'approved') return;
+    if (customer.status === 'active') return;
     await refreshCustomer();
     timeout = setTimeout(() => {
       refreshCustomerPeriodically();


### PR DESCRIPTION
This was breaking the `ProcessingApplication` screen and not refreshing the customer. 

A customer can be non-active yet have a KYC of accepted